### PR TITLE
WordPress version 5.4.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: bungeshea
 Donate link: https://bungeshea.com/donate/
 Tags: functionality, functions.php
-Tested up to: 4.9.4
+Tested up to: 5.4.1
 Stable tag: 2.0.0
 License: MIT
 License URI: https://opensource.org/licenses/MIT


### PR DESCRIPTION
Still works perfectly. So update is to prevent warning described at https://generatewp.com/new-policy-changes-wordpress-plugin-directory/

Sorry if there's a better way to do this but it's my first time.